### PR TITLE
Use RIPE Atlas Cousteau to reuse some code

### DIFF
--- a/lib/Atlas/ProbeInfo.py
+++ b/lib/Atlas/ProbeInfo.py
@@ -3,9 +3,10 @@ import urllib2
 import urllib
 import json
 
-PROBE_API_HOST='https://atlas.ripe.net'
-PROBE_API_URL='%s/api/v1/probe/' % ( PROBE_API_HOST )
+#  pip install https://github.com/RIPE-NCC/ripe-atlas-cousteau/zipball/latest
+from ripe.atlas.cousteau import ProbeRequest
 
+PROBE_API_HOST='https://atlas.ripe.net'
 PROBE_API_URL_ARCHIVE='%s/api/v1/probe-archive/' % ( PROBE_API_HOST )
 
 def query_archive(**kwargs):
@@ -29,29 +30,14 @@ def query_archive(**kwargs):
       objects[ obj['id'] ] = obj
    return objects
 
+
 def query(**kwargs):
-   if 'day' in kwargs:
-      return query_archive(**kwargs)
-   if not 'limit' in kwargs:
-      kwargs['limit'] = 200
-   objects = {} 
-   url = "%s?%s" % (PROBE_API_URL, urllib.urlencode( kwargs ) )
-   try:
-      conn = urllib2.urlopen( url )
-   except:
-      raise ValueError("URL fetch error on: %s" % (url) )
-   result = json.load( conn )
-   objects = result['objects'] 
-   while result['meta']['next'] != None:
-      continurl = "%s/%s" % ( PROBE_API_HOST, result['meta']['next'] )
-      #print continurl
-      try:
-         contin = urllib2.urlopen( continurl )
-      except:
-         raise ValueError("URL fetch error on: %s" % (continurl) )
-      result = json.load( contin )
-      objects.extend( result['objects'] )
-   keyed_objects = {}
-   for obj in objects:
-      keyed_objects[ obj['id'] ] = obj
-   return keyed_objects
+    if 'day' in kwargs:
+        return query_archive(**kwargs)
+
+    keyed_objects = {}
+    probes = ProbeRequest(**kwargs)
+    for probe in probes:
+        keyed_objects[probe["id"]] = probe
+
+    return keyed_objects

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ripe.atlas.sagan==0.1.15
 dnspython==1.11.1
 ipaddress==1.0.6
 arrow==0.4.2
+git+https://github.com/RIPE-NCC/ripe-atlas-cousteau.git@latest#egg=ripe.atlas.cousteau


### PR DESCRIPTION
Saw this code after I added a new feature on Cousteau for getting probes/measurements meta data easily, so I thought to reuse it and clean some of this code. This adds the obvious dependency on Cousteau, if you don't want to have additional dependencies except the basic core libraries feel free to skip it.