### PR TITLE
Combine country and probe_ids in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ analysing the results.  It can contain various parts:
 examples are provided in the _examples_ directory. For probe selection it is mandatory to either have _country_ , _probetag_ , or _probe_ids_
 defined. It is possible to combine _probetab_ and _country_ (which will take
 all the probes with that probetag in the specified country/countries).
+It is also possible to combine _probe_ids_ and _country_: after selecting the probes
+in the specified country/ies, the _probe_ids_ specified will be added (any duplicates
+will be removed).
 Without a *locations* section, the capital of *country* (or the first country, if *country*
 is a list) is used for probe selection (see below).
 

--- a/prepare.py
+++ b/prepare.py
@@ -596,6 +596,18 @@ if __name__ == '__main__':
             selected_probes += sel_probes_for_cc
          print >>sys.stderr, "found: %d probes" % ( len( sel_probes_for_cc ) )
          print >>sys.stderr, "END country: %s" % ( country )
+         # If there are probes manually selected in config.json, add them as well
+         if 'probe_ids' in basedata:
+            probes_from_ids = []
+            selected_probeids = []
+            print >>sys.stderr, "Adding probes from probe_ids list"
+            for sel_prb in selected_probes:
+               selected_probeids.append(sel_prb['probe_id'])
+            probes_from_ids = do_probe_selection_from_ids( basedata['probe_ids'] )
+            # Add probes from probe_ids without duplicates
+            for prb in probes_from_ids:
+               if prb['probe_id'] not in selected_probeids:
+                  selected_probes.append(prb)
       elif 'probetag' in basedata:
          print >>sys.stderr, "finding probes for tag: %s" % ( basedata['probetag'] )
          selected_probes = do_probe_selection_from_tag( basedata['probetag'] ) 


### PR DESCRIPTION
This update gives the possibility to combine country and probe_ids in config.json. If both are specified, after selecting the probes in the specified country/ies, the probe_ids specified will be added (any duplicates will be removed).

(This is useful in case the user wants to add a limited amount of interesting probes, e.g. probes just outside country borders which fall in the area of interest of the country/ies researched)
