### PR TITLE
Allow reading Google Maps API key from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ _~/.geonames/auth_.
 
 for more information on GeoNames see http://www.geonames.org/export/web-services.html
 
+This script also relies on Google Maps Geocoding API to geocode a location from list of probes. The limit is
+[2500 free requests](https://developers.google.com/maps/documentation/geocoding/usage-limits). You can pass your own
+API key by using environment variable `GOOGLEMAPS_API_KEY`.
+
 ## measure.py
 
 This script runs one-off measurements for the probes specified in

--- a/prepare.py
+++ b/prepare.py
@@ -407,13 +407,23 @@ def capital_city_for_country( country_code ):
 def locstr2latlng( locstring ):
    try:
       locstr = urllib2.quote( locstring )
-      geocode_url = "http://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false" % locstr
+      geocode_url = "https://maps.googleapis.com/maps/api/geocode/json?address=%s&sensor=false" % locstr
+      apikey = os.getenv('GOOGLEMAPS_API_KEY')
+      if apikey:
+         geocode_url += "&key=%s" % apikey
+
       req = urllib2.urlopen(geocode_url)
+
       resp = json.loads(req.read())
+      if 'error_message' in resp:
+         raise SystemExit("Maps geocode error: %s" % resp['error_message'])
+
+
       ll = resp['results'][0]['geometry']['location']
-      return ( ll['lat'], ll['lng'] )
-   except:
+      return (ll['lat'], ll['lng'])
+   except (ValueError, IndexError):
       print "could not determine lat/long for '%s'" % ( locstring )
+      pass
 
 
 def extract_websites_in_tld(country_code, max_results=100):


### PR DESCRIPTION
## Description
`prepare.py` has external dependency to Google Maps Geocoding API, which allows [2500 free requests](https://developers.google.com/maps/documentation/geocoding/usage-limits) per day per IP address. It is easy to reach this limit within an office with a static IP, or when dealing with hundreds of locations that have to be geocoded.

Therefore, it would be beneficial to provide a way to pass the API key to the script.

We will also raise an exception in case that API limit is reached, or if any other error message occurs.